### PR TITLE
Remove trailing spaces from Ruby code and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ About
 CSSO does structure-optimization for css.
 Css is usually reduced more than in half in uncompressed and around 15% in gzipped.
 
-### A real-world example 
+### A real-world example
 A living rails application css - some written in less, some handwritten):
 
 |        | Original     |  sass  | yui 2.4.7  | csso  | % of original

--- a/bin/ruby_csso
+++ b/bin/ruby_csso
@@ -20,6 +20,6 @@ if ($stdin.tty? && ARGV.empty?) || ARGV.delete('-h') || ARGV.delete('--help')
 else
   # Well, lets read those files
   css = ARGF.read
-  
+
   puts Csso.optimize(css, maniac)
 end

--- a/lib/csso-rails.rb
+++ b/lib/csso-rails.rb
@@ -3,5 +3,5 @@ require 'csso'
 if defined?(Rails)
   require 'csso/rails'
 else
-  require 'csso'  
+  require 'csso'
 end

--- a/lib/csso.rb
+++ b/lib/csso.rb
@@ -25,11 +25,11 @@ module Csso
       Optimizer.new.optimize(css, structural_optimization)
     end
   end
-  
-  
+
+
   class Optimizer
     include CallJS
-    
+
     def optimize(css, structural_optimization=true)
       return nil unless css.is_a?(String)
       return css if css.size <= 3
@@ -38,5 +38,5 @@ module Csso
       end
     end
   end
-  
+
 end

--- a/lib/csso/loader.rb
+++ b/lib/csso/loader.rb
@@ -20,13 +20,13 @@ module Csso
       @js_path = js_path || Pathname(__FILE__).dirname.join('js').to_s
       @cxt = V8::Context.new
       @environment = ModifiedEnvironment.new(@cxt, :path => @js_path)
-      
+
       [Util, Path, Fs].each do |native|
         @environment.native(native.to_s.downcase, native.new)
       end
-      
+
       [Process, Console].each do|replace|
-        @cxt[replace.to_s.downcase] = replace.new      
+        @cxt[replace.to_s.downcase] = replace.new
       end
     end
 

--- a/lib/csso/rails.rb
+++ b/lib/csso/rails.rb
@@ -1,9 +1,9 @@
 require "action_controller/railtie"
 
 module Csso
-  
+
   COMPRESSOR_SYM = :csso
-  
+
   class Railtie < ::Rails::Railtie
     initializer "csso.environment", :after => "sprockets.environment" do
       CssCompressor.register
@@ -15,19 +15,19 @@ module Csso
         app.config.assets.css_compressor = :csso
       end
     end
-        
+
   end
-  
+
   class CssCompressor
     def compress(css)
       require 'csso'
       #TODO: settings?
       Csso.optimize(css, true)
-    end    
-    
+    end
+
     def self.register
       Sprockets::Compressors.register_css_compressor(COMPRESSOR_SYM, 'Csso::CssCompressor', :default => true)
     end
   end
-  
+
 end

--- a/spec/csso/csso_spec.rb
+++ b/spec/csso/csso_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe Csso do
-  
+
   it "should optimize css" do
     subject.optimize("a  {\ncolor: white; }").should == "a{color:#fff}"
   end
@@ -9,20 +9,20 @@ describe Csso do
   it "should optimize structure" do
     subject.optimize("a  {\ncolor: white; } a{color: red;}").should == "a{color:red}"
   end
-  
+
   it "should optimize structure" do
     pending "original csso is a bit broken at the moment"
     # FIXME: csso produces "a{color:#fff;color:red}" on this :(
     subject.optimize("a  {\ncolor: white; } a{color: #ff0000;}").should == "a{color:red}"
   end
-  
+
   it "should optimize structure in maniac mode" do
     subject.optimize("a  {\ncolor: white; } a{color: #ff0000;}", true).should == "a{color:red}"
   end
-  
+
   it 'should produce no error on empty input' do
     subject.optimize(nil).should == nil
     subject.optimize("").should == ""
   end
-  
+
 end


### PR DESCRIPTION
Small, but important code clean up. Trailing spaces are forbidden in many code styles.
