### PR TITLE
Use not so strong version requiremments for therubyracer

### DIFF
--- a/csso-rails.gemspec
+++ b/csso-rails.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "therubyracer", "~> 0.10.2"
+  s.add_dependency "therubyracer", ">= 0.10.2"
   s.add_dependency "commonjs", "~> 0.2.0"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Current `therubyracer` requiremment is too strong. This library willn’t broke anything in future versions, so it’s safe to use last one.

Current requiremment doesn’t allow me to use your cool gem in our projects :(.
