### PR TITLE
Allow to use with Sprockets without Rails

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,14 +33,21 @@ add `gem 'csso-rails'` to your gemfile, and that’s it!
 Upon including it becomes the default compressor even if sass is included too.
 More explicit way – set in config: `config.assets.css_compressor = :csso`.
 
+### Sprockets
+
+If you use Sprockets without Rails:
+
+```ruby
+require 'csso'
+Csso::CssCompressor.register!
+sprockets_env.css_compressor = :csso
+```
 
 ### In Plain Ruby
 
 ```ruby
- require 'rubygems'
- gem 'csso-rails'
- require 'csso'
- puts Csso.optimize("a{ color: #FF0000; }") # produces "a{color:red}"
+require 'csso'
+puts Csso.optimize("a{ color: #FF0000; }") # produces "a{color:red}"
 ```
 
 In _maniac mode_(`Csso.optimize(css, true)`, default for pipeline) CSS is processed several times until it stops getting lighter (there're cases when original csso does not do all optimizations for no reason).

--- a/lib/csso-rails.rb
+++ b/lib/csso-rails.rb
@@ -1,7 +1,2 @@
 require 'csso'
-
-if defined?(Rails)
-  require 'csso/rails'
-else
-  require 'csso'
-end
+require 'csso/rails' if defined?(Rails)

--- a/lib/csso.rb
+++ b/lib/csso.rb
@@ -2,6 +2,7 @@ require 'v8'
 require 'csso/version'
 require 'csso/utils'
 require 'csso/loader'
+require 'csso/compressor'
 
 module Csso
 

--- a/lib/csso/compressor.rb
+++ b/lib/csso/compressor.rb
@@ -1,0 +1,17 @@
+module Csso
+  class CssCompressor
+    def compress(css)
+      require 'csso'
+      #TODO: settings?
+      Csso.optimize(css, true)
+    end
+
+    def self.register!
+      if Sprockets.respond_to? :register_compressor
+        Sprockets.register_compressor('text/css', COMPRESSOR_SYM, 'Csso::CssCompressor')
+      else
+        Sprockets::Compressors.register_css_compressor(COMPRESSOR_SYM, 'Csso::CssCompressor', :default => true)
+      end
+    end
+  end
+end

--- a/lib/csso/rails.rb
+++ b/lib/csso/rails.rb
@@ -6,7 +6,7 @@ module Csso
 
   class Railtie < ::Rails::Railtie
     initializer "csso.environment", :after => "sprockets.environment" do
-      CssCompressor.register
+      CssCompressor.register!
     end
 
     # saas-rails-3.2.4(and may be others) sets itself as default, ignoring config? => override :(
@@ -16,22 +16,6 @@ module Csso
       end
     end
 
-  end
-
-  class CssCompressor
-    def compress(css)
-      require 'csso'
-      #TODO: settings?
-      Csso.optimize(css, true)
-    end
-
-    def self.register
-      if Sprockets.respond_to? :register_compressor
-        Sprockets.register_compressor('text/css', COMPRESSOR_SYM, 'Csso::CssCompressor')
-      else
-        Sprockets::Compressors.register_css_compressor(COMPRESSOR_SYM, 'Csso::CssCompressor', :default => true)
-      end
-    end
   end
 
 end


### PR DESCRIPTION
I have a lot of projects with Sprockets, but without Rails (for example, [easings.net](https://github.com/ai/easings.net)) and I can’t live and don’t move them to `csso-rails` :D.
