### PR TITLE
Don't lock execjs version in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,15 +2,13 @@ PATH
   remote: .
   specs:
     csso-rails (0.3.0)
-      execjs (~> 1.4)
+      execjs (>= 1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    execjs (1.4.0)
-      multi_json (~> 1.0)
+    execjs (2.0.1)
     minitest (5.0.3)
-    multi_json (1.7.6)
     rake (10.0.4)
 
 PLATFORMS

--- a/csso-rails.gemspec
+++ b/csso-rails.gemspec
@@ -21,8 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  #TODO: loosen execjs dependency?
-  s.add_dependency 'execjs', '~>1.4'
+  s.add_dependency 'execjs', '>= 1'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest'


### PR DESCRIPTION
More free `execjs` version requirement
